### PR TITLE
Feat title in data

### DIFF
--- a/ebay.py
+++ b/ebay.py
@@ -69,11 +69,14 @@ def writeOutAndClose(storeName, currentData, currentReport):
 		timeFile.write(f"{currentDate}")
 	
 	# write out the data
-	logger.info(f"[{storeName}] Writing DATA...")
-	with open(f"/tmp/DATA", 'w', newline='') as dataFile:
-		writer = csv.writer(dataFile)
-		for itemid in currentData:
-			writer.writerow([itemid, currentData[itemid]])
+	logger.info(f"[{storeName}] Writing DATA.xlsx...")
+	wb_data = XL.Workbook()
+	ws_data = wb_data.active
+	
+	for itemid in currentData:
+		ws_data.append([itemid, currentData[itemid]])
+		
+	wb_data.save("/tmp/DATA.xlsx")
 				
 	# write out the report
 	if currentReport:
@@ -90,7 +93,7 @@ def writeOutAndClose(storeName, currentData, currentReport):
 		bucket.Object(f"{storeName}/REPORT - {storeName} - {currentDate.strftime('%m-%d-%Y %I:%M%p')}.xlsx").put(Body=open("/tmp/REPORT.xlsx", 'rb'))
 
 	bucket.Object(f"{storeName}/LASTRUN").put(Body=open("/tmp/LASTRUN", 'rb'))	
-	bucket.Object(f"{storeName}/DATA").put(Body=open(f"/tmp/DATA", 'rb'))
+	bucket.Object(f"{storeName}/DATA").put(Body=open(f"/tmp/DATA.xlsx", 'rb'))
 	
 def getLastRunTime(storeName):
 	try:

--- a/ebay.py
+++ b/ebay.py
@@ -105,10 +105,16 @@ def getLastRunTime(storeName):
 		
 def getLastRunData(storeName):
 	try:
-		previousDataFileObj = bucket.Object(f"{storeName}/DATA")
-		res = previousDataFileObj.get()
-		ret = dict([each.split(',') for each in res['Body'].read().decode('utf-8').split()])
-		previousDataFileObj.delete()
+		bucket.download_file(f"{storeName}/DATA", "/tmp/previousDataFile.xlsx")
+		lastData_wb = XL.load_workbook(filename = "/tmp/previousDataFile.xlsx", read_only=True)
+		lastData_ws = lastData_wb['Sheet']
+		
+		ret = {}
+		
+		for row in lastData_ws.rows:
+			ret[row[0].value] = row[1].value
+		
+		bucket.Object(f"{storeName}/DATA").delete()
 		return ret
 	except Exception as err:
 		logger.error(f"[{storeName}] Error reading DATA: {err}")

--- a/ebay.py
+++ b/ebay.py
@@ -75,22 +75,25 @@ def getLastRunData(storeName):
 		lastData_wb = XL.load_workbook(filename = "/tmp/previousDataFile.xlsx", read_only=True)
 		lastData_ws = lastData_wb['Sheet']
 		
-		ret = {}
+		prices = {}
+		titles = {}
 		
 		for row in lastData_ws.rows:
-			ret[row[0].value] = row[1].value
+			prices[row[0].value] = row[1].value
+			titles[row[0].value] = row[2].value
 		
 		bucket.Object(f"{storeName}/DATA").delete()
-		return ret
+		return prices,titles
 	except Exception as err:
 		logger.error(f"[{storeName}] Error reading DATA: {err}")
-		return {}
+		return {},{}
 		
 def main(event, context):
 	
 	for storeName in storeNames:
 		previousFilename = ''
 		previousData = {}
+		previousData_titles {}
 		previousTimestamp = ''
 
 		currentData = {}
@@ -101,7 +104,7 @@ def main(event, context):
 		previousTimeObj = getLastRunTime(storeName)
 		
 		# Load previous data file into memory if it exists
-		previousData = getLastRunData(storeName)
+		previousData,previousData_titles = getLastRunData(storeName)
 		
 		currentPage = 1
 		totalPages = 1
@@ -185,7 +188,7 @@ def main(event, context):
 						'last_price' : previousData[itemid],
 						'price_difference' : '',
 						'status' : 'REMOVED',
-						'title' : '',
+						'title' : previousData_titles[itemid],
 						'url' : ''
 						}
 					currentReport.append(toAdd)


### PR DESCRIPTION
This closes issue #12 - Include `title` for removed listings

We now:

- store the data file in `xlsx` using `openpyxl`
- store the title in the data file
- read the tile back in and include in report for removed listings

Tested using `shox_depot` and verified the title is now included in the report (by adding dummy listings with fake `itemid`s and `title`s to `DATA`):

https://www.screencast.com/t/7EWgO1kmEey4

Also verified it ran successfully (albeit without being able to read in the previous data file) with the stores being used in production (`wheelsNparts`, `supremesuspensions.inc`, `motofab555`).
